### PR TITLE
Moves map into independent component, refactors map icons

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,6 +11,9 @@
   <link rel="stylesheet" href="https://unpkg.com/leaflet@1.6.0/dist/leaflet.css"
     integrity="sha512-xwE/Az9zrjBIphAcBb3F6JVqxf46+CDLwfLMHloNu6KEQCAWi6HcDUbeOfBIptF7tcCzusKFjFw2yuvEpDL9wQ=="
     crossorigin="" />
+  <script src="https://unpkg.com/leaflet@1.6.0/dist/leaflet.js"
+    integrity="sha512-gZwIG9x3wUXg2hdXF6+rVkLF/0Vi9U8D2Ntg4Ga5I5BZpVkVxlJWbSQtXPSiUTtC0TjtGOmxa1AJPuV0CPthew=="
+    crossorigin=""></script>
   <title>Document</title>
 </head>
 
@@ -73,9 +76,6 @@
         tortor. Praesent libero lacus, commodo ac turpis sit amet, tincidunt faucibus dolor.
       </p>
     </section>
-    <script src="https://unpkg.com/leaflet@1.6.0/dist/leaflet.js"
-      integrity="sha512-gZwIG9x3wUXg2hdXF6+rVkLF/0Vi9U8D2Ntg4Ga5I5BZpVkVxlJWbSQtXPSiUTtC0TjtGOmxa1AJPuV0CPthew=="
-      crossorigin=""></script>
 </body>
 
 </html>

--- a/index.html
+++ b/index.html
@@ -29,7 +29,7 @@
     </header>
     <section class="squirrel-map">
       <div class="map-wrapper">
-          <div id="mapid"></div>
+          <div id="mapid" component="map"></div>
           <div>Map squirrel icon made by <a href="https://www.flaticon.com/authors/eucalyp" title="Eucalyp">Eucalyp</a> from <a
               href="https://www.flaticon.com/" title="Flaticon">www.flaticon.com</a></div>
       </div>

--- a/src/components/map.js
+++ b/src/components/map.js
@@ -1,0 +1,82 @@
+import "../config/keys";
+
+
+export function Map() {
+  const MAPBOX_TOKEN = require("../config/keys").MAPBOX_TOKEN;
+  const squirrelMap = L.map('mapid').setView([40.782864, -73.965355], 15);
+
+  //Add icons for each squirrel type
+  const cinnamonSquirrelIcon = L.icon({
+    iconUrl: "/assets/map_icons/cinnamon-squirrel-icon.svg",
+
+    iconSize: [20, 20], // size of icon
+    iconAnchor: [10, 20], // set anchor relative to icon
+    popupAnchor: [5, -18] //set popup relative to anchor
+  });
+
+  const graySquirrelIcon = L.icon({
+    iconUrl: "/assets/map_icons/gray-squirrel-icon.svg",
+
+    iconSize: [20, 20], // size of icon
+    iconAnchor: [10, 20], // set anchor relative to icon
+    popupAnchor: [5, -18] //set popup relative to anchor
+  });
+
+  const blackSquirrelIcon = L.icon({
+    iconUrl: "/assets/map_icons/black-squirrel-icon.svg",
+
+    iconSize: [20, 20], // size of icon
+    iconAnchor: [10, 20], // set anchor relative to icon
+    popupAnchor: [5, -18] //set popup relative to anchor
+  });
+
+  // Create base tile for map
+  L.tileLayer('https://api.mapbox.com/styles/v1/{id}/tiles/{z}/{x}/{y}?access_token={accessToken}', {
+    attribution: 'Map data &copy; <a href="https://www.openstreetmap.org/">OpenStreetMap</a> contributors, <a href="https://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>, Imagery © <a href="https://www.mapbox.com/">Mapbox</a>',
+    maxZoom: 18,
+    minZoom: 14,
+    id: 'mapbox/streets-v11',
+    tileSize: 512,
+    zoomOffset: -1,
+    accessToken: `${MAPBOX_TOKEN}`
+  }).addTo(squirrelMap);
+
+  // Plot squirrel markers and popups on mapwhen geoJSON is loaded from Api
+  const xhr = new XMLHttpRequest();
+  xhr.open('GET', 'https://data.cityofnewyork.us/resource/vfnx-vebw.geojson');
+  xhr.onload = () => {
+    const data = JSON.parse(xhr.response);
+    L.geoJSON(data, {
+      //Set squirrel icon based on geoJSON property primary_fur_color
+      pointToLayer: function (feature, latlng) {
+        const primaryFurColor = feature.properties.primary_fur_color;
+        if (primaryFurColor === "Cinnamon") {
+          return L.marker(latlng, { icon: cinnamonSquirrelIcon });
+        } else if (primaryFurColor === "Black") {
+          return L.marker(latlng, { icon: blackSquirrelIcon });
+        } else {
+          return L.marker(latlng, { icon: graySquirrelIcon });
+        }
+      },
+      onEachFeature: function (feature, layer) {
+        const { primary_fur_color, shift, foraging, climbing, running } = feature.properties;
+
+        const dateString = feature.properties.date.replace(/(\d{2})(\d{2})(\d+)/, '$1/$2/$3');
+        const date = new Date(dateString);
+
+        layer.bindPopup(
+          `<h2>Details<h2>
+          <ul>
+            <li>Date: ${dateString}</li>
+            <li>Fur Color: ${primary_fur_color}</li>
+            <li>Shift: ${shift}</li>
+            <li>Foraging: ${foraging}</li>
+            <li>Running: ${running}</li>
+            <li>Climibing: ${climbing}</li>
+          </ul>`
+        );
+      }
+    }).addTo(squirrelMap);
+  };
+  xhr.send();
+}

--- a/src/components/map.js
+++ b/src/components/map.js
@@ -6,29 +6,17 @@ export function Map() {
   const squirrelMap = L.map('mapid').setView([40.782864, -73.965355], 15);
 
   //Add icons for each squirrel type
-  const cinnamonSquirrelIcon = L.icon({
-    iconUrl: "/assets/map_icons/cinnamon-squirrel-icon.svg",
-
-    iconSize: [20, 20], // size of icon
-    iconAnchor: [10, 20], // set anchor relative to icon
-    popupAnchor: [5, -18] //set popup relative to anchor
+  const SquirrelIcon = L.Icon.extend({
+    options: {
+      iconSize: [20, 20], // size of icon
+      iconAnchor: [10, 20], // set anchor relative to icon
+      popupAnchor: [5, -18] //set popup relative to anchor
+    }
   });
 
-  const graySquirrelIcon = L.icon({
-    iconUrl: "/assets/map_icons/gray-squirrel-icon.svg",
-
-    iconSize: [20, 20], // size of icon
-    iconAnchor: [10, 20], // set anchor relative to icon
-    popupAnchor: [5, -18] //set popup relative to anchor
-  });
-
-  const blackSquirrelIcon = L.icon({
-    iconUrl: "/assets/map_icons/black-squirrel-icon.svg",
-
-    iconSize: [20, 20], // size of icon
-    iconAnchor: [10, 20], // set anchor relative to icon
-    popupAnchor: [5, -18] //set popup relative to anchor
-  });
+  const graySquirrelIcon = new SquirrelIcon({ iconUrl: "/assets/map_icons/gray-squirrel-icon.svg" }),
+        cinnamonSquirrelIcon = new SquirrelIcon({ iconUrl: "/assets/map_icons/cinnamon-squirrel-icon.svg" }),
+        blackSquirrelIcon = new SquirrelIcon({ iconUrl: "/assets/map_icons/black-squirrel-icon.svg" });
 
   // Create base tile for map
   L.tileLayer('https://api.mapbox.com/styles/v1/{id}/tiles/{z}/{x}/{y}?access_token={accessToken}', {

--- a/src/index.js
+++ b/src/index.js
@@ -1,82 +1,10 @@
 import "./styles/index.scss";
 import "./config/keys";
-
+import { Map } from './components/map';
 
 const MAPBOX_TOKEN = require("./config/keys").MAPBOX_TOKEN;
 
 window.addEventListener("DOMContentLoaded", () => {
-  //Center of map set to 86th Street Central Park
-  const squirrelMap = L.map('mapid').setView([40.782864, -73.965355], 15);
-
-
-  const cinnamonSquirrelIcon = L.icon ({
-    iconUrl: "/assets/map_icons/cinnamon-squirrel-icon.svg",
-
-    iconSize: [20, 20], // size of icon
-    iconAnchor: [10, 20], // set anchor relative to icon
-    popupAnchor: [5, -18] //set popup relative to anchor
-  });
-
-  const graySquirrelIcon = L.icon({
-    iconUrl: "/assets/map_icons/gray-squirrel-icon.svg",
-
-    iconSize: [20, 20], // size of icon
-    iconAnchor: [10, 20], // set anchor relative to icon
-    popupAnchor: [5, -18] //set popup relative to anchor
-  });
-
-  const blackSquirrelIcon = L.icon({
-    iconUrl: "/assets/map_icons/black-squirrel-icon.svg",
-
-    iconSize: [20, 20], // size of icon
-    iconAnchor: [10, 20], // set anchor relative to icon
-    popupAnchor: [5, -18] //set popup relative to anchor
-  });
-
-  L.tileLayer('https://api.mapbox.com/styles/v1/{id}/tiles/{z}/{x}/{y}?access_token={accessToken}', {
-    attribution: 'Map data &copy; <a href="https://www.openstreetmap.org/">OpenStreetMap</a> contributors, <a href="https://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>, Imagery © <a href="https://www.mapbox.com/">Mapbox</a>',
-    maxZoom: 18,
-    minZoom: 14,
-    id: 'mapbox/streets-v11',
-    tileSize: 512,
-    zoomOffset: -1,
-    accessToken: `${ MAPBOX_TOKEN }`
-  }).addTo(squirrelMap);
-
-  const xhr = new XMLHttpRequest();
-  xhr.open('GET', 'https://data.cityofnewyork.us/resource/vfnx-vebw.geojson');
-  xhr.onload = () => {
-    const data = JSON.parse(xhr.response);
-    L.geoJSON(data, {
-      pointToLayer: function (feature, latlng) {
-        const primaryFurColor = feature.properties.primary_fur_color;
-        if (primaryFurColor === "Cinnamon") {
-          return L.marker(latlng, { icon: cinnamonSquirrelIcon });
-        } else if (primaryFurColor === "Black") {
-          return L.marker(latlng, { icon: blackSquirrelIcon });
-        } else {
-          return L.marker(latlng, { icon: graySquirrelIcon });
-        }
-      },
-      onEachFeature: function(feature, layer) {
-        const { primary_fur_color, shift, foraging, climbing, running } = feature.properties;
-
-        const dateString = feature.properties.date.replace(/(\d{2})(\d{2})(\d+)/ , '$1/$2/$3');
-        const date = new Date(dateString);
-
-        layer.bindPopup(
-          `<h2>Details<h2>
-          <ul>
-            <li>Date: ${dateString}</li>
-            <li>Fur Color: ${primary_fur_color}</li>
-            <li>Shift: ${shift}</li>
-            <li>Foraging: ${foraging}</li>
-            <li>Running: ${running}</li>
-            <li>Climibing: ${climbing}</li>
-          </ul>`
-        );
-      }
-    }).addTo(squirrelMap);
-  };
-  xhr.send();
+  const map = document.querySelector("[component=map");
+  new Map(map);
 });

--- a/src/index.js
+++ b/src/index.js
@@ -2,8 +2,6 @@ import "./styles/index.scss";
 import "./config/keys";
 import { Map } from './components/map';
 
-const MAPBOX_TOKEN = require("./config/keys").MAPBOX_TOKEN;
-
 window.addEventListener("DOMContentLoaded", () => {
   const map = document.querySelector("[component=map");
   new Map(map);


### PR DESCRIPTION
### Summary
+ transfers map code into its own component
+ refactors map icons to clean up code
+ adds components directory for future components

### Details
The basic idea is that a property is added to each HTML element with a component key/value pair.

In order to use the map component I had to
+ add a key `component=<component_name>` inside of each HTML element where it is called in `index.js`
+ import the component inside of `index.js`
+ inside `index.js` create a new instance of the component when `DOMContentLoaded`
+ export all the code from the component as a single function
+ make sure to transfer all required constants from `index.js` into the component

### Code Snippets
From `index.html`
```
<div id="mapid" component="map"></div>
```
From `index.js`
```
import { Map } from './components/map';
window.addEventListener("DOMContentLoaded", () => {
  const map = document.querySelector("[component=map");
  new Map(map);
});
```
From `map.js`
```
export function Map() {
  const MAPBOX_TOKEN = require("../config/keys").MAPBOX_TOKEN;
  const squirrelMap = L.map('mapid').setView([40.782864, -73.965355], 15);
//... other code here
}
```

One gotcha is to remember to update any api key references to be inside of the component rather than `index.js`.