### PR TITLE
Add volunteer stories to both sides of card

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,7 +15,7 @@
     integrity="sha512-gZwIG9x3wUXg2hdXF6+rVkLF/0Vi9U8D2Ntg4Ga5I5BZpVkVxlJWbSQtXPSiUTtC0TjtGOmxa1AJPuV0CPthew=="
     crossorigin=""></script>
   <script src="https://d3js.org/d3.v4.min.js"></script>
-  <title>Document</title>
+  <title>Squirrels of Central Park</title>
 </head>
 
 <body>
@@ -24,7 +24,7 @@
       <h1 class="main-box-shadow brown-wrapper">Squirrels of Central Park</h1>
       <div>
         <p>
-          In October 2018, 323 volunteer Squirrel Sighters representing Squirrel Census counted the Eastern gray squirrels in
+          In October 2018, 323 volunteer Squirrel Sighters representing <a href="https://www.thesquirrelcensus.com/" target="_blank">The Squirrel Census</a> counted the Eastern gray squirrels in
           Central Park. This projects aims to visualize the data in a playful way that embodies the spirit of the project.
         </p>
         <img src="./src/assets/squirrel-mascot.svg" alt="squirrel-mascot" class="main-box-shadow" id="squirrel-mascot">
@@ -57,16 +57,18 @@
           </div>
         </div>
         <br>
-        <p>Click on individual squirrels to get more information about a particular siting.</p>
+        <p>Click on individual squirrels to get more information about a particular sighting.</p>
       </div>
     </section>
     <section class="section-stories">
         <div id="card">
           <div class="front brown-wrapper main-box-shadow" id="card-front">
-            <h2>Click Card To See Volunteer Stories!</h2>
+            <h2>Click this card to see more volunteer stories</h2>
+            <p id="story-details-front"></p>
           </div>
           <div class="back brown-wrapper main-box-shadow" id="card-back">
-            <p id="story-details"></p>
+            <h2>Click this card to see more volunteer stories</h2>
+            <p id="story-details-back"></p>
           </div>
         </div>
     </section>

--- a/src/components/stories.js
+++ b/src/components/stories.js
@@ -1,20 +1,22 @@
 export function Stories() {
 
-  const fetchRandomStory = () => (
+  const fetchRandomStory = (elementId) => (
     fetch('https://data.cityofnewyork.us/resource/gfqj-f768.json')
     .then(response => response.json())
     .then(data => 
-      document.getElementById('story-details').innerHTML = data[Math.floor(Math.random() * data.length)].note_squirrel_park_stories
+      document.getElementById(elementId).innerHTML = data[Math.floor(Math.random() * data.length)].note_squirrel_park_stories
   ));
+  fetchRandomStory('story-details-front');
 
   const card = document.getElementById('card');
 
   document.getElementById('card-front').addEventListener('click', function () {
-    fetchRandomStory();
+    fetchRandomStory('story-details-back');
     card.classList.toggle('flipped');
   }, false);
 
   document.getElementById('card-back').addEventListener('click', function () {
+    fetchRandomStory('story-details-front');
     card.classList.toggle('flipped');
   }, false);
 }

--- a/src/styles/base/_layout.scss
+++ b/src/styles/base/_layout.scss
@@ -28,6 +28,7 @@ h2 {
   text-align: center;
   font-size: 1.5rem;
   opacity: .7;
+  padding: 0rem 1.5rem;
 }
 
 p {
@@ -68,6 +69,10 @@ header p {
   text-align: center;
 }
 
+header a {
+  text-decoration: underline;
+}
+
 header div {
   display: flex;
   flex-direction: column;
@@ -99,6 +104,7 @@ header img {
 
   h2 {
     font-size: 2.5rem;
+    padding: 0rem 1.5rem;
   }
 
   //header

--- a/src/styles/components/_stories.scss
+++ b/src/styles/components/_stories.scss
@@ -1,6 +1,5 @@
 .section-stories {
-  width: 75vw;
-  height: 400px;
+  width: 78vw;
   position: relative;
   perspective: 800px;
   margin-bottom: 4rem;
@@ -8,18 +7,16 @@
 
 #card {
   width: 100%;
-  height: 100%;
   position: absolute;
   transform-style: preserve-3d;
   transition: transform 1s;
 }
 
 #card .front, #card .back {
-  margin: 0;
-  display: block;
-  position: absolute;
+  display: flex;
+  flex-direction: column;
   width: 100%;
-  height: 100%;
+  position: absolute;
   backface-visibility: hidden;
 }
 
@@ -28,14 +25,13 @@
 }
 
 #card .front {
-  left: 8px;
   display: flex;
   justify-content: center;
   align-items: center;
 }
 
 #card .back {
-  right: 10px;
+  right: 4px;
   transform: rotateY( 180deg);
 }
 
@@ -46,5 +42,16 @@
 @media only screen and (min-width: 900px) {
   .section-stories {
     min-width: 85vw;
+  }
+  #card {
+    margin-top: 2rem;
+  }
+
+  #card .front {
+    left: 0px;
+  }
+
+  #card .back {
+    right: 0px;
   }
 }


### PR DESCRIPTION
### Summary
A volunteer story now loads as soon as the page is visited. Stories now appear on both sides of the card and new ones are loaded on each click of the card. 

In addition to this feature change, a few other minor changes were made:
+ Page title was updated from `Document` to `Squirrels of Central Park`
+ Link was added to [The Squirrel Census Homepage](https://www.thesquirrelcensus.com/)
+ Typo was fixed
+ Overall styling on the story card improved for responsiveness at different screen sizes

### Technical notes
Rather than updating the innerHTML of a particular element, `fetchRandomStory` function now accepts an HTML id as an argument. On flipping a card, the innerHTML of the opposite side is filled in with the fetched value.